### PR TITLE
Fix: Ignore void damage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>xyz.blujay</groupId>
     <artifactId>AutoTotem</artifactId>
-    <version>1.2.2</version>
+    <version>1.2.3</version>
     <packaging>jar</packaging>
 
     <name>AutoTotem</name>

--- a/src/main/java/xyz/blujay/autototem/events/PlayerDamagedEvent.java
+++ b/src/main/java/xyz/blujay/autototem/events/PlayerDamagedEvent.java
@@ -17,6 +17,9 @@ public class PlayerDamagedEvent implements Listener {
         if(e.getEntity() instanceof Player p){
             //If player received lethal damage
             if(e.getFinalDamage() >= p.getHealth()){
+                // Ignore void damage
+                if (e.getCause().equals(EntityDamageEvent.DamageCause.VOID)) return;
+
                 //Check if player has a totem in their inv
                 var inv = p.getInventory();
                 var firstTotemSlot = inv.first(Material.TOTEM_OF_UNDYING);


### PR DESCRIPTION
Added check if damage cause is void, since in Vanilla totems won't be used in this case and may cause issues with other plugins otherwise, for example Gravestone plugins (in my case) 